### PR TITLE
Custom Rounded Corner and Padding preferences [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -5403,6 +5403,18 @@ public final class Settings {
                 Global.DEVELOPMENT_SETTINGS_ENABLED;
 
         /**
+         * Setting to allow setting rounded corner size and content padding
+         */
+        public static final String SYSUI_ROUNDED_SIZE = "sysui_rounded_size";
+        public static final String SYSUI_ROUNDED_CONTENT_PADDING = "sysui_rounded_content_padding";
+
+        /**
+         * Setting to disable rounded corner preferences and use frameworks values instead
+         * @hide
+         */
+        public static final String SYSUI_ROUNDED_FWVALS = "sysui_rounded_fwvals";
+
+        /**
          * When the user has enable the option to have a "bug report" command
          * in the power menu.
          * @deprecated Use {@link android.provider.Settings.Global#BUGREPORT_IN_POWER_MENU} instead

--- a/packages/SystemUI/src/com/android/systemui/ScreenDecorations.java
+++ b/packages/SystemUI/src/com/android/systemui/ScreenDecorations.java
@@ -40,6 +40,7 @@ import android.graphics.Rect;
 import android.graphics.Region;
 import android.hardware.display.DisplayManager;
 import android.os.Handler;
+import android.os.UserHandle;
 import android.os.HandlerThread;
 import android.os.SystemProperties;
 import android.provider.Settings.Secure;
@@ -120,6 +121,10 @@ public class ScreenDecorations extends SystemUI implements Tunable {
         mRotation = RotationUtils.getExactRotation(mContext);
         mWindowManager = mContext.getSystemService(WindowManager.class);
         updateRoundedCornerRadii();
+
+         Dependency.get(Dependency.MAIN_HANDLER).post(
+                () -> Dependency.get(TunerService.class).addTunable(this, SIZE));
+
         if (hasRoundedCorners() || shouldDrawCutout()) {
             setupDecorations();
         }
@@ -193,9 +198,6 @@ public class ScreenDecorations extends SystemUI implements Tunable {
         DisplayMetrics metrics = new DisplayMetrics();
         mWindowManager.getDefaultDisplay().getMetrics(metrics);
         mDensity = metrics.density;
-
-        Dependency.get(Dependency.MAIN_HANDLER).post(
-                () -> Dependency.get(TunerService.class).addTunable(this, SIZE));
 
         // Watch color inversion and invert the overlay as needed.
         SecureSetting setting = new SecureSetting(mContext, mHandler,
@@ -350,7 +352,8 @@ public class ScreenDecorations extends SystemUI implements Tunable {
     }
 
     private boolean hasRoundedCorners() {
-        return mRoundedDefault > 0 || mRoundedDefaultBottom > 0 || mRoundedDefaultTop > 0;
+        return mRoundedDefault > 0 || mRoundedDefaultBottom > 0 || mRoundedDefaultTop > 0 ||
+                Secure.getIntForUser(mContext.getContentResolver(), SIZE, 0, UserHandle.USER_CURRENT) != 0;
     }
 
     private boolean shouldDrawCutout() {
@@ -444,8 +447,13 @@ public class ScreenDecorations extends SystemUI implements Tunable {
     @Override
     public void onTuningChanged(String key, String newValue) {
         mHandler.post(() -> {
-            if (mOverlay == null) return;
             if (SIZE.equals(key)) {
+               if (mOverlay == null) {
+                    if (newValue != null && Integer.parseInt(newValue) != 0)
+                        setupDecorations();
+                    else
+                        return;
+                }
                 int size = mRoundedDefault;
                 int sizeTop = mRoundedDefaultTop;
                 int sizeBottom = mRoundedDefaultBottom;
@@ -462,7 +470,8 @@ public class ScreenDecorations extends SystemUI implements Tunable {
                 if (sizeBottom == 0) {
                     sizeBottom = size;
                 }
-
+  
+                updateWindowVisibilities();
                 setSize(mOverlay.findViewById(R.id.left), sizeTop);
                 setSize(mOverlay.findViewById(R.id.right), sizeTop);
                 setSize(mBottomOverlay.findViewById(R.id.left), sizeBottom);


### PR DESCRIPTION
RoundedCorners: Use even if resource values are 0

Change-Id: Ib8031f420220cdd19da3ced86c066c2d3282d517
Signed-off-by: Kshitij Gupta <kshitijgm@gmail.com>

Settings: Add Rounded corner strings to Settings.Secure

Change-Id: Ifa158a2138e96dbbed68bae0ff178212b061bc65
Signed-off-by: Kshitij Gupta <kshitijgm@gmail.com>

base: Allow using framework values for rounded corners [1/2]

Change-Id: I246a34f0b52ca595f6bcfd7367631673db25c0cf
Signed-off-by: Kshitij Gupta <kshitijgm@gmail.com>

base: corners: Evaluate framework values correctly [1/2]

ScreenDecorations: corners: Fixes for pie

- If the device has framework value 0dp for corners, it would ideally
  misbehave when we override it with our secure setting.
- To fix this, restore and modify default hasRoundedCorners logic, add
  SIZE tunable unconditionally, setupDecorations if necessary
  onTuningChanged, and make sure to setVisibility when needed.

Change-Id: I9719ab8e18cda2be4db33fa8d871945b6722e2bd
Signed-off-by: Kshitij Gupta <kshitijgm@gmail.com>

StatusBar: corners: Fix dp evaluation

- The secure setting stores the value in dp, not in native px. Divide
  our px value with density to get true dp value.
- Also, since dp value is stored as an int, use getDimension instead of
  getDimensionPixelSize to  prevent loss during division and rounding
  off.

Change-Id: I5380de944efa324d7633370ed2eda587566e02a3
Signed-off-by: Kshitij Gupta <kshitijgm@gmail.com>