### PR TITLE
VibratorService: Sync patches for OnePlus Vibrator HAL

### DIFF
--- a/core/res/res/values/lineage_config.xml
+++ b/core/res/res/values/lineage_config.xml
@@ -45,4 +45,10 @@
     <!-- The list of components which should be forced to be enabled. -->
     <string-array name="config_forceEnabledComponents" translatable="false">
     </string-array>
+
+    <!-- OnePlus uses a proprietary vibrator hal to utilize the new powerful motor since the
+         OnePlus 7 Pro. This HAL expects a different format for the data instead of the usual (ms)
+         timing(the duration which the vibrator is expected to vibrate for). -->
+    <bool name="config_hasOnePlusHapticMotor">false</bool>
+
 </resources>

--- a/core/res/res/values/lineage_symbols.xml
+++ b/core/res/res/values/lineage_symbols.xml
@@ -40,4 +40,8 @@
     <java-symbol type="array" name="config_deviceDisabledComponents" />
     <java-symbol type="array" name="config_globallyDisabledComponents" />
     <java-symbol type="array" name="config_forceEnabledComponents" />
+
+    <!-- OnePlus haptic motor -->
+    <java-symbol type="bool" name="config_hasOnePlusHapticMotor" />
+
 </resources>

--- a/services/core/java/com/android/server/VibratorService.java
+++ b/services/core/java/com/android/server/VibratorService.java
@@ -113,13 +113,13 @@ public class VibratorService extends IVibratorService.Stub
     private static final int ONEPLUS_SCALE = 100000;
     private static final int ONEPLUS_BREAK_CONSTANT = 9990;
     private static final int ONEPLUS_EFFECT_THRESHOLD = 100;
-    private static final long ONEPLUS_EFFECT_CLICK = 4509994;
+    private static final long ONEPLUS_EFFECT_CLICK = 5909995;
     private static final long ONEPLUS_EFFECT_DOUBLE_CLICK = 3509993;
     private static final long ONEPLUS_EFFECT_HEAVY_CLICK = 1600051;
-    private static final long ONEPLUS_EFFECT_TEXTURE_TICK = 900021;
-    private static final long ONEPLUS_EFFECT_TICK = 1100111;
+    private static final long ONEPLUS_EFFECT_TEXTURE_TICK = 1100111;
+    private static final long ONEPLUS_EFFECT_TICK = 1100031;
     private static final long ONEPLUS_EFFECT_POP = 1100041;
-    private static final long ONEPLUS_EFFECT_THUD = 3509009;
+    private static final long ONEPLUS_EFFECT_THUD = 3000003;
 
     // A mapping from the intensity adjustment to the scaling to apply, where the intensity
     // adjustment is defined as the delta between the default intensity level and the user selected


### PR DESCRIPTION
> OnePlus proprietary vibrator hal doesn't work the way the open-source one does.

It seems that these commits provide an effective solution to bring up the vibrator hal,
& only work when config_hasOnePlusHapticMotor is set to true.

Test: Build & vibrator works as expected